### PR TITLE
Add alpha tip3p to FF benchmarks

### DIFF
--- a/proteinbenchmark/force_fields.py
+++ b/proteinbenchmark/force_fields.py
@@ -226,6 +226,11 @@ force_fields = {
         "water_model": "opc3",
         "water_model_file": Path(ff_directory, "opc3-1.0.0.offxml"),
     },
+    "null-0.0.3-4-mer-aaqaa3-1e3-tip3p": {
+        "force_field_file": Path(ff_directory, "null-0.0.3-4-mer-aaqaa3-1e3-opc3-NAGL.offxml"),
+        "water_model": "tip3p",
+        "water_model_file": None,
+    },
     "null-0.0.3-4-mer-aaqaa3-1e3-2-opc3": {
         "force_field_file": Path(ff_directory, "null-0.0.3-4-mer-aaqaa3-1e3-2-opc3-NAGL.offxml"),
         "water_model": "opc3",


### PR DESCRIPTION
This wasn't already present in forcefields.py. @chapincavender could you please have a look and just confirm that this is correct, and also I've selected the right alpha FF file? Thanks!